### PR TITLE
Fix a few wiring problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "async": "^1.4.2",
+    "babel-cli": "^6.9.0",
     "babel-core": "^6.2.1",
     "babel-loader": "^6.2.0",
     "css-loader": "^0.15.6",

--- a/src/backend/app.js
+++ b/src/backend/app.js
@@ -9,7 +9,7 @@ app.set('port', 3000);
 app.set('views', __dirname + '/views');
 app.set('view engine', 'ejs');
 app.use(bodyParser.json());
-app.use(express.static(path.resolve(__dirname, 'public')));
+app.use(express.static(path.resolve(__dirname, '../../public')));
 
 const main = () => {
   server(app)

--- a/src/backend/views/app.ejs
+++ b/src/backend/views/app.ejs
@@ -27,6 +27,6 @@
   </head>
   <body>
     <div id="main"></div>
+    <script src="/build.js"></script>
   </body>
-  <script src="/build.js"></script>
 </html>


### PR DESCRIPTION
- Allow `npm run server` without a global babel-cli – fixes #1 
- Fix the 404-s on build.js & vendors.js
- Move `<script>` into `<body>` to be more HTML-spec-compliant and keep Firefox dev tools happy
